### PR TITLE
fix(SideNav): use child.icon for each submenu item in accordion

### DIFF
--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -73,32 +73,34 @@ export function SideNav({ items, setOpen, className }: SideNavProps) {
                                     <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
                                 )}
                             </AccordionTrigger>
-                            <AccordionContent className="ml-4 mt-2 space-y-4 pb-1">
+                           <AccordionContent className="ml-4 mt-2 space-y-4 pb-1">
                                 {item.children?.map((child) => (
                                     <Link
-                                        key={child.title}
-                                        href={child.href}
-                                        onClick={() => {
-                                            if (setOpen) setOpen(false);
-                                        }}
+                                    key={child.title}
+                                    href={child.href}
+                                    onClick={() => {
+                                        if (setOpen) setOpen(false)
+                                    }}
+                                    className={cn(
+                                        buttonVariants({ variant: 'ghost' }),
+                                        'group flex h-12 justify-start gap-x-3',
+                                        path === child.href && 'bg-muted font-bold hover:bg-muted',
+                                    )}
+                                    >
+                                    {/* Use child.icon aqui em vez de item.icon */}
+                                    <child.icon className={cn('h-5 w-5', child.color)} />
+                                    <div
                                         className={cn(
-                                            buttonVariants({ variant: "ghost" }),
-                                            "group flex h-12 justify-start gap-x-3",
-                                            path === child.href && "bg-muted font-bold hover:bg-muted"
+                                        'text-base duration-200',
+                                        !isOpen && className,
                                         )}
                                     >
-                                        <item.icon className={cn("h-5 w-5", child.color)} />
-                                        <div
-                                            className={cn(
-                                                "text-base duration-200",
-                                                !isOpen && className
-                                            )}
-                                        >
-                                            {child.title}
-                                        </div>
+                                        {child.title}
+                                    </div>
                                     </Link>
                                 ))}
-                            </AccordionContent>
+                                </AccordionContent>
+
                         </AccordionItem>
                     </Accordion>
                 ) : (


### PR DESCRIPTION
This pull request addresses an issue in the SideNav component where all submenu items incorrectly used their parent item's icon. The update ensures that each child item within the AccordionContent uses its specific icon, enhancing the visual accuracy and usability of the sidebar navigation. The changes have been thoroughly tested to ensure functionality and visual integrity. This update improves the overall user experience by providing correct visual cues for each submenu link.