### PR TITLE
fix(sidebar): Correct visibility of sub-accordions when sidebar is closed; tooltip issue still unresolved

### DIFF
--- a/src/components/layout/side-nav.tsx
+++ b/src/components/layout/side-nav.tsx
@@ -40,94 +40,93 @@ export function SideNav({ items, setOpen, className }: SideNavProps) {
 
     return (
         <nav className="space-y-2">
-            {items.map((item) =>
-                item.isChidren ? (
-                    <Accordion
-                        type="single"
-                        collapsible
-                        className="space-y-2"
-                        key={item.title}
-                        value={openItem}
-                        onValueChange={setOpenItem}
-                    >
-                        <AccordionItem value={item.title} className="border-none">
-                            <AccordionTrigger
-                                className={cn(
-                                    buttonVariants({ variant: "ghost" }),
-                                    "group relative flex h-12 justify-between px-4 py-2 text-base duration-200 hover:bg-muted hover:no-underline"
-                                )}
-                            >
-                                <div>
-                                    <item.icon className={cn("h-5 w-5", item.color)} />
-                                </div>
-                                <div
-                                    className={cn(
-                                        "absolute left-12 text-base duration-200",
-                                        !isOpen && className
-                                    )}
-                                >
-                                    {item.title}
-                                </div>
+      {items.map((item) =>
+        item.isChidren ? (
+          <Accordion
+            type="single"
+            collapsible
+            className="space-y-2"
+            key={item.title}
+            value={openItem}
+            onValueChange={setOpenItem}
+          >
+            <AccordionItem value={item.title} className="border-none ">
+              <AccordionTrigger
+                className={cn(
+                  buttonVariants({ variant: 'ghost' }),
+                  'group relative flex h-12 justify-between px-4 py-2 text-base duration-200 hover:bg-muted hover:no-underline',
+                )}
+              >
+                <div>
+                  <item.icon className={cn('h-5 w-5', item.color)} />
+                </div>
+                <div
+                  className={cn(
+                    'absolute left-12 text-base duration-200 ',
+                    !isOpen && className,
+                  )}
+                >
+                  {item.title}
+                </div>
 
-                                {isOpen && (
-                                    <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
-                                )}
-                            </AccordionTrigger>
-                            <AccordionContent className="ml-4 mt-2 space-y-2 pb-1">
-                                {item.children?.map((child) => (
-                                    <Link
-                                        key={child.title}
-                                        href={child.href}
-                                        onClick={() => {
-                                            if (setOpen) setOpen(false)
-                                        }}
-                                        className={cn(
-                                            buttonVariants({ variant: 'ghost' }),
-                                            'group flex h-12 justify-start gap-x-3',
-                                            path === child.href && 'bg-muted font-bold hover:bg-muted',
-                                        )}
-                                    >
-                                        {/* Use child.icon aqui em vez de item.icon */}
-                                        <child.icon className={cn('h-5 w-5', child.color)} />
-                                        <div
-                                            className={cn(
-                                                'text-base duration-200',
-                                                !isOpen && className,
-                                            )}
-                                        >
-                                            {child.title}
-                                        </div>
-                                    </Link>
-                                ))}
-                            </AccordionContent>
-
-                        </AccordionItem>
-                    </Accordion>
-                ) : (
-                    <Link
-                        key={item.title}
-                        href={item.href}
-                        onClick={() => {
-                            if (setOpen) setOpen(false);
-                        }}
-                        className={cn(
-                            buttonVariants({ variant: "ghost" }),
-                            "group relative flex h-12 justify-start",
-                            path === item.href && "bg-muted font-bold hover:bg-muted"
-                        )}
+                {isOpen && (
+                  <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+                )}
+              </AccordionTrigger>
+              <AccordionContent className="mt-2 space-y-4 pb-1">
+                {item.children?.map((child) => (
+                  <Link
+                    key={child.title}
+                    href={child.href}
+                    onClick={() => {
+                      if (setOpen) setOpen(false)
+                    }}
+                    className={cn(
+                      buttonVariants({ variant: 'ghost' }),
+                      'group relative flex h-12 justify-start gap-x-3',
+                      path === child.href &&
+                        'bg-muted font-bold hover:bg-muted',
+                    )}
+                  >
+                    <child.icon className={cn('h-5 w-5', child.color)} />
+                    <div
+                      className={cn(
+                        'absolute left-12 text-base duration-200',
+                        !isOpen && className,
+                      )}
                     >
-                        <item.icon className={cn("h-5 w-5", item.color)} />
-                        <span
-                            className={cn(
-                                "absolute left-12 text-base duration-200",
-                                !isOpen && className
-                            )}
-                        >
-                            {item.title}
-                        </span>
-                    </Link>
-                )
+                      {child.title}
+                    </div>
+                  </Link>
+                ))}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        ) : (
+          <Link
+            key={item.title}
+            href={item.href}
+            onClick={() => {
+              if (setOpen) setOpen(false)
+            }}
+            className={cn(
+              buttonVariants({ variant: 'ghost' }),
+              'group relative flex h-12 justify-start',
+              path === item.href && 'bg-muted font-bold hover:bg-muted',
             )}
-        </nav>
+          >
+            <item.icon className={cn('h-5 w-5', item.color)} />
+            <span
+              className={cn(
+                'absolute left-12 text-base duration-200',
+                !isOpen && className,
+              )}
+            >
+              {item.title}
+            </span>
+          </Link>
+        ),
+      )}
+    </nav>
     );
 }


### PR DESCRIPTION
I have identified the root cause of the issue with the visibility of the sub-accordions in the sidebar: it was the absence of the 'position' property in the 'Link' component. This fix has been implemented. However, there is still an outstanding issue with the tooltip that is supposed to appear on hover. I haven't had the chance to review and address this aspect yet. I suspect that the problem might be related to the z-index of the sidebar.